### PR TITLE
Fix ios .podspec & .m values with new plugin name

### DIFF
--- a/ios/Classes/VideoCompressPlugin.m
+++ b/ios/Classes/VideoCompressPlugin.m
@@ -1,5 +1,5 @@
 #import "VideoCompressPlugin.h"
-#import <video_compress/video_compress-Swift.h>
+#import <video_compress_plus/video_compress_plus-Swift.h>
 
 @implementation VideoCompressPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/ios/video_compress_plus.podspec
+++ b/ios/video_compress_plus.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = 'video_compress'
+  s.name             = 'video_compress_plus'
   s.version          = '0.3.0'
   s.swift_version    = '5.0'
   s.summary          = 'A new flutter plugin project.'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_compress_plus
 description: Light library of video manipulation of Flutter. Compress video, remove audio, get video thumbnail from dart code.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/kamaravichow/VideoCompressPlus
 
 environment:


### PR DESCRIPTION
This pull request addresses two issues with the video_compress_plus package, specifically affecting iOS devices:

1. No podspec found for `video_compress_plus` in `.symlinks/plugins/video_compress_plus/ios`
2. Lexical or Preprocessor Issue (Xcode): 'video_compress/video_compress-Swift.h' file not found

I have thoroughly tested these changes on an iOS device and confirmed that video compression functionality is now working as expected.

Please review these changes and consider merging them into the main branch.

Thank you!